### PR TITLE
Remove shadowed variable in optional argument example

### DIFF
--- a/book/variables-and-functions/README.md
+++ b/book/variables-and-functions/README.md
@@ -949,7 +949,7 @@ concatenation.
 
 ```ocaml env=main
 # let concat ?sep x y =
-    let sep = match sep with None -> "" | Some x -> x in
+    let sep = match sep with None -> "" | Some z -> z in
     x ^ sep ^ y
 val concat : ?sep:string -> string -> string -> string = <fun>
 # concat "foo" "bar"             (* without the optional argument *)


### PR DESCRIPTION
I found the reuse of `x` to be confusing.
While it got me to think about scopes I feel it detracted from the point of this example.